### PR TITLE
Added `conventional_label.yml` for release notes

### DIFF
--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,0 +1,11 @@
+# Warning, do not check out untrusted code with
+# the pull_request_target event.
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1


### PR DESCRIPTION
- Added `conventional-label.yml` to auto-generate release notes. See [here.](https://github.com/bcoe/conventional-release-labels).
- Finishes implementation of auto release notes