### PR TITLE
Add sample weighting to `TransformerClassifier` 🏋️

### DIFF
--- a/src/otc/data/dataloader.py
+++ b/src/otc/data/dataloader.py
@@ -78,7 +78,8 @@ class TabDataLoader:
         Raises:
             StopIteration: stopping criterion.
         Returns:
-            Tuple[torch.Tensor | None, torch.Tensor, torch.Tensor]: (X_cat), X_cont, y
+            Tuple[torch.Tensor | None, torch.Tensor, torch.Tensor]: (X_cat), X_cont,
+            weight, y
         """
         if self.i >= self.dataset_len:
             raise StopIteration

--- a/src/otc/data/dataset.py
+++ b/src/otc/data/dataset.py
@@ -23,7 +23,8 @@ class TabDataset(Dataset):
         self,
         x: pd.DataFrame | npt.ndarray,
         y: pd.Series | npt.ndarray,
-        features: list[str] | None = None,
+        weight: pd.Series | npt.ndarray | None = None,
+        feature_names: list[str] | None = None,
         cat_features: list[str] | None = None,
         cat_unique_counts: tuple[int, ...] | None = None,
     ):
@@ -31,27 +32,36 @@ class TabDataset(Dataset):
         Tabular data set holding data for the model.
 
         Args:
-            x (pd.DataFrame): feature matrix.
-            y (pd.Series): target.
-            cat_features (Optional[List[str]], optional): List with categorical columns.
+            x (pd.DataFrame | npt.ndarray): feature matrix
+            y (pd.Series | npt.ndarray): target
+            weight (pd.Series | npt.ndarray | None, optional): weights of samples. If
+            not provided all samples are given a weight of 1. Defaults to None.
+            feature_names (list[str] | None, optional): name of features. Defaults to
+            None.
+            cat_features (list[str] | None, optional): List with categorical columns.
             Defaults to None.
-            cat_unique_counts (Optional[Tuple[int]], optional): Number of categories per
-            categorical feature. Defaults to None.
+            cat_unique_counts (tuple[int, ...] | None, optional): Number of categories
+            per categorical feature. Defaults to None.
         """
         self._cat_unique_counts = () if not cat_unique_counts else cat_unique_counts
 
         # calculate cat indices
-        features = [] if not features else features
+        feature_names = [] if not feature_names else feature_names
         cat_features = [] if not cat_features else cat_features
-        self._cat_idx = [features.index(i) for i in cat_features if i in features]
+        self._cat_idx = [
+            feature_names.index(i) for i in cat_features if i in feature_names
+        ]
 
         # calculate cont indices
-        cont_features = [f for f in features if f not in cat_features]
-        self._cont_idx = [features.index(i) for i in cont_features if i in features]
+        cont_features = [f for f in feature_names if f not in cat_features]
+        self._cont_idx = [
+            feature_names.index(i) for i in cont_features if i in feature_names
+        ]
 
         # pd 2 np
         x = x.values if isinstance(x, pd.DataFrame) else x
         y = y.values if isinstance(y, pd.Series) else y
+        weight = weight.values if isinstance(weight, pd.Series) else weight
 
         assert (
             x.shape[0] == y.shape[0]
@@ -70,6 +80,17 @@ class TabDataset(Dataset):
             self.x_cat = torch.tensor(x[:, self._cat_idx]).int()
         self.x_cont = torch.tensor(x[:, self._cont_idx]).float()
 
+        # set weights
+        weight = (
+            torch.tensor(weight).float()
+            if weight is not None
+            else torch.ones(len(self.y)).float()
+        )
+        assert (
+            y.shape[0] == weight.shape[0]
+        ), "Length of traget must match length of weight."
+        self.weight = weight
+
     def __len__(self) -> int:
         """
         Length of dataset.
@@ -81,7 +102,7 @@ class TabDataset(Dataset):
 
     def __getitem__(
         self, idx: int
-    ) -> tuple[torch.Tensor | None, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Get sample for model.
 
@@ -89,11 +110,12 @@ class TabDataset(Dataset):
             idx (int): index of item.
 
         Returns:
-            Tuple[torch.Tensor | None, torch.Tensor, torch.Tensor]:
-            x_cat (if present if present otherwise None), x_cont and y.
+            Tuple[torch.Tensor | None, torch.Tensor, torch.Tensor torch.Tensor]:
+            x_cat (if present if present otherwise None), x_cont, weight and y.
         """
         return (
             self.x_cat[idx] if self.x_cat else None,
             self.x_cont[idx],
+            self.weight[idx],
             self.y[idx],
         )

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -37,7 +37,7 @@ class TestDataLoader:
         training_data = TabDataset(
             x=x,
             y=y,
-            features=["a", "b", "c"],
+            feature_names=["a", "b", "c"],
             cat_features=None,
             cat_unique_counts=None,
         )
@@ -70,7 +70,7 @@ class TestDataLoader:
             x=x,
             y=y,
             cat_features=["a"],
-            features=["a", "b", "c"],
+            feature_names=["a", "b", "c"],
             cat_unique_counts=tuple([100]),
         )
         train_loader = TabDataLoader(
@@ -101,7 +101,7 @@ class TestDataLoader:
         training_data = TabDataset(
             x=x,
             y=y,
-            features=["a", "b", "c"],
+            feature_names=["a", "b", "c"],
             cat_features=None,
             cat_unique_counts=None,
         )


### PR DESCRIPTION
- weight samples in training set similar to how it's done in `CatBoost`. Therefore, more recent observations become more important.
- fix context manager for mixed-precision calculations to include also the model's output. See [here](https://pytorch.org/docs/stable/amp.html).